### PR TITLE
fix: remove kuberhealthy

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -2,7 +2,6 @@ filepath: ""
 helmfiles:
 - path: helmfiles/cert-manager/helmfile.yaml
 - path: helmfiles/jx/helmfile.yaml
-- path: helmfiles/kuberhealthy/helmfile.yaml
 - path: helmfiles/nginx/helmfile.yaml
 - path: helmfiles/secret-infra/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml

--- a/helmfiles/jx/helmfile.yaml
+++ b/helmfiles/jx/helmfile.yaml
@@ -73,11 +73,5 @@ releases:
   values:
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
   - jx-values.yaml
-- chart: jxgh/jx-kh-check
-  version: 0.0.78
-  name: health-checks-jx
-  values:
-  - ../../versionStream/charts/jxgh/health-checks-jx/values.yaml.gotmpl
-  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
kuberhealthy is not maintained, so removing it by default